### PR TITLE
Upgrade to Junit 5

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,11 @@
   "jvm_version": "17",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "notification-service:com.piggymetrics.notification.NotificationServiceShouldUseSpringBoot22Test",
+      "auth-service:com.piggymetrics.auth.AuthServiceShouldUseSpringBoot22Test",
+      "account-service:com.piggymetrics.account.AccountServiceShouldUseSpringBoot22Test"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/account-service/pom.xml
+++ b/account-service/pom.xml
@@ -95,7 +95,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.6.201602180812</version>
+				<version>0.8.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/account-service/src/test/java/com/piggymetrics/account/AccountServiceShouldUseSpringBoot22Test.java
+++ b/account-service/src/test/java/com/piggymetrics/account/AccountServiceShouldUseSpringBoot22Test.java
@@ -1,0 +1,17 @@
+package com.piggymetrics.account;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootVersion;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AccountServiceShouldUseSpringBoot22Test {
+    @Test
+    void shouldBeUsingSpringBoot22() {
+        String version = SpringBootVersion.getVersion();
+        assertNotNull(version, "Spring Boot version should not be null");
+        assertTrue(version.startsWith("2.2."),
+                "Expected Spring Boot 2.2.x but got: " + version);
+    }
+}

--- a/account-service/src/test/java/com/piggymetrics/account/client/StatisticsServiceClientFallbackTest.java
+++ b/account-service/src/test/java/com/piggymetrics/account/client/StatisticsServiceClientFallbackTest.java
@@ -1,21 +1,20 @@
 package com.piggymetrics.account.client;
 
 import com.piggymetrics.account.domain.Account;
-import org.junit.Before;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.rule.OutputCapture;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import static org.hamcrest.Matchers.containsString;
 
 /**
  * @author cdov
  */
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest(properties = {
         "feign.hystrix.enabled=true"
 })
@@ -23,10 +22,9 @@ public class StatisticsServiceClientFallbackTest {
     @Autowired
     private StatisticsServiceClient statisticsServiceClient;
 
-    @Rule
-    public final OutputCapture outputCapture = new OutputCapture();
+    private final OutputCapture outputCapture = new OutputCapture();
 
-    @Before
+    @BeforeEach
     public void setup() {
         outputCapture.reset();
     }

--- a/account-service/src/test/java/com/piggymetrics/account/controller/AccountControllerTest.java
+++ b/account-service/src/test/java/com/piggymetrics/account/controller/AccountControllerTest.java
@@ -5,14 +5,14 @@ import com.google.common.collect.ImmutableList;
 import com.piggymetrics.account.domain.*;
 import com.piggymetrics.account.service.AccountService;
 import com.sun.security.auth.UserPrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -25,7 +25,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class AccountControllerTest {
 
@@ -39,7 +39,7 @@ public class AccountControllerTest {
 
 	private MockMvc mockMvc;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 		this.mockMvc = MockMvcBuilders.standaloneSetup(accountController).build();

--- a/account-service/src/test/java/com/piggymetrics/account/repository/AccountRepositoryTest.java
+++ b/account-service/src/test/java/com/piggymetrics/account/repository/AccountRepositoryTest.java
@@ -5,19 +5,19 @@ import com.piggymetrics.account.domain.Currency;
 import com.piggymetrics.account.domain.Item;
 import com.piggymetrics.account.domain.Saving;
 import com.piggymetrics.account.domain.TimePeriod;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 import java.util.Date;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DataMongoTest
 public class AccountRepositoryTest {
 

--- a/account-service/src/test/java/com/piggymetrics/account/service/AccountServiceTest.java
+++ b/account-service/src/test/java/com/piggymetrics/account/service/AccountServiceTest.java
@@ -4,16 +4,17 @@ import com.piggymetrics.account.client.AuthServiceClient;
 import com.piggymetrics.account.client.StatisticsServiceClient;
 import com.piggymetrics.account.domain.*;
 import com.piggymetrics.account.repository.AccountRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -31,7 +32,7 @@ public class AccountServiceTest {
 	@Mock
 	private AccountRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -48,9 +49,11 @@ public class AccountServiceTest {
 		assertEquals(account, found);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWhenNameIsEmpty() {
-		accountService.findByName("");
+		assertThrows(IllegalArgumentException.class, () -> {
+			accountService.findByName("");
+		});
 	}
 
 	@Test
@@ -137,13 +140,15 @@ public class AccountServiceTest {
 		verify(statisticsClient, times(1)).updateStatistics("test", account);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWhenNoAccountsExistedWithGivenName() {
 		final Account update = new Account();
 		update.setIncomes(Arrays.asList(new Item()));
 		update.setExpenses(Arrays.asList(new Item()));
 
 		when(accountService.findByName("test")).thenReturn(null);
-		accountService.saveChanges("test", update);
+		assertThrows(IllegalArgumentException.class, () -> {
+			accountService.saveChanges("test", update);
+		});
 	}
 }

--- a/auth-service/pom.xml
+++ b/auth-service/pom.xml
@@ -75,7 +75,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.6.201602180812</version>
+				<version>0.8.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/auth-service/src/test/java/com/piggymetrics/auth/AuthServiceApplicationTests.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/AuthServiceApplicationTests.java
@@ -1,11 +1,11 @@
 package com.piggymetrics.auth;
 
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class AuthServiceApplicationTests {
 

--- a/auth-service/src/test/java/com/piggymetrics/auth/AuthServiceShouldUseSpringBoot22Test.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/AuthServiceShouldUseSpringBoot22Test.java
@@ -1,0 +1,17 @@
+package com.piggymetrics.auth;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootVersion;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+public class AuthServiceShouldUseSpringBoot22Test {
+    @Test
+    void shouldBeUsingSpringBoot22() {
+        String version = SpringBootVersion.getVersion();
+        assertNotNull(version, "Spring Boot version should not be null");
+        assertTrue(version.startsWith("2.2."),
+                "Expected Spring Boot 2.2.x but got: " + version);
+    }
+}

--- a/auth-service/src/test/java/com/piggymetrics/auth/controller/UserControllerTest.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/controller/UserControllerTest.java
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.piggymetrics.auth.domain.User;
 import com.piggymetrics.auth.service.UserService;
 import com.sun.security.auth.UserPrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -21,7 +21,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class UserControllerTest {
 
@@ -35,7 +35,7 @@ public class UserControllerTest {
 
 	private MockMvc mockMvc;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 		this.mockMvc = MockMvcBuilders.standaloneSetup(accountController).build();

--- a/auth-service/src/test/java/com/piggymetrics/auth/repository/UserRepositoryTest.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/repository/UserRepositoryTest.java
@@ -2,20 +2,20 @@ package com.piggymetrics.auth.repository;
 
 import com.piggymetrics.auth.domain.User;
 import com.piggymetrics.auth.service.security.MongoUserDetailsService;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.mongo.embedded.EmbeddedMongoAutoConfiguration;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DataMongoTest
 public class UserRepositoryTest {
 

--- a/auth-service/src/test/java/com/piggymetrics/auth/service/UserServiceTest.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/service/UserServiceTest.java
@@ -2,8 +2,8 @@ package com.piggymetrics.auth.service;
 
 import com.piggymetrics.auth.domain.User;
 import com.piggymetrics.auth.repository.UserRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -11,6 +11,7 @@ import java.util.Optional;
 
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 
 public class UserServiceTest {
 
@@ -20,7 +21,7 @@ public class UserServiceTest {
 	@Mock
 	private UserRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -36,7 +37,7 @@ public class UserServiceTest {
 		verify(repository, times(1)).save(user);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailWhenUserAlreadyExists() {
 
 		User user = new User();
@@ -44,6 +45,8 @@ public class UserServiceTest {
 		user.setPassword("password");
 
 		when(repository.findById(user.getUsername())).thenReturn(Optional.of(new User()));
-		userService.create(user);
+		assertThrows(IllegalArgumentException.class, () -> {
+			userService.create(user);
+		});
 	}
 }

--- a/auth-service/src/test/java/com/piggymetrics/auth/service/security/MongoUserDetailsServiceTest.java
+++ b/auth-service/src/test/java/com/piggymetrics/auth/service/security/MongoUserDetailsServiceTest.java
@@ -2,8 +2,8 @@ package com.piggymetrics.auth.service.security;
 
 import com.piggymetrics.auth.domain.User;
 import com.piggymetrics.auth.repository.UserRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -11,7 +11,8 @@ import org.springframework.security.core.userdetails.UsernameNotFoundException;
 
 import java.util.Optional;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -24,7 +25,7 @@ public class MongoUserDetailsServiceTest {
 	@Mock
 	private UserRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -40,8 +41,10 @@ public class MongoUserDetailsServiceTest {
 		assertEquals(user, loaded);
 	}
 
-	@Test(expected = UsernameNotFoundException.class)
+	@Test
 	public void shouldFailToLoadByUsernameWhenUserNotExists() {
-		service.loadUserByUsername("name");
+		assertThrows(UsernameNotFoundException.class, () -> {
+			service.loadUserByUsername("name");
+		});
 	}
 }

--- a/notification-service/pom.xml
+++ b/notification-service/pom.xml
@@ -96,7 +96,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.6.201602180812</version>
+				<version>0.8.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/notification-service/src/test/java/com/piggymetrics/notification/NotificationServiceShouldUseSpringBoot22Test.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/NotificationServiceShouldUseSpringBoot22Test.java
@@ -1,0 +1,15 @@
+package com.piggymetrics.notification;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.SpringBootVersion;
+import static org.junit.jupiter.api.Assertions.*;
+
+public class NotificationServiceShouldUseSpringBoot22Test {
+    @Test
+    void shouldBeUsingSpringBoot22() {
+        String version = SpringBootVersion.getVersion();
+        assertNotNull(version, "Spring Boot version should not be null");
+        assertTrue(version.startsWith("2.2."),
+                "Expected Spring Boot 2.2.x but got: " + version);
+    }
+}

--- a/notification-service/src/test/java/com/piggymetrics/notification/controller/RecipientControllerTest.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/controller/RecipientControllerTest.java
@@ -8,14 +8,14 @@ import com.piggymetrics.notification.domain.NotificationType;
 import com.piggymetrics.notification.domain.Recipient;
 import com.piggymetrics.notification.service.RecipientService;
 import com.sun.security.auth.UserPrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -26,7 +26,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class RecipientControllerTest {
 
@@ -40,7 +40,7 @@ public class RecipientControllerTest {
 
 	private MockMvc mockMvc;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 		this.mockMvc = MockMvcBuilders.standaloneSetup(recipientController).build();

--- a/notification-service/src/test/java/com/piggymetrics/notification/repository/RecipientRepositoryTest.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/repository/RecipientRepositoryTest.java
@@ -6,20 +6,20 @@ import com.piggymetrics.notification.domain.NotificationSettings;
 import com.piggymetrics.notification.domain.NotificationType;
 import com.piggymetrics.notification.domain.Recipient;
 import org.apache.commons.lang.time.DateUtils;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DataMongoTest
 public class RecipientRepositoryTest {
 

--- a/notification-service/src/test/java/com/piggymetrics/notification/service/EmailServiceImplTest.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/service/EmailServiceImplTest.java
@@ -2,8 +2,8 @@ package com.piggymetrics.notification.service;
 
 import com.piggymetrics.notification.domain.NotificationType;
 import com.piggymetrics.notification.domain.Recipient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Captor;
 import org.mockito.InjectMocks;
@@ -17,7 +17,7 @@ import javax.mail.internet.MimeMessage;
 import java.io.IOException;
 import java.util.Properties;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -36,7 +36,7 @@ public class EmailServiceImplTest {
 	@Captor
 	private ArgumentCaptor<MimeMessage> captor;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 		when(mailSender.createMimeMessage())

--- a/notification-service/src/test/java/com/piggymetrics/notification/service/NotificationServiceImplTest.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/service/NotificationServiceImplTest.java
@@ -4,8 +4,8 @@ import com.google.common.collect.ImmutableList;
 import com.piggymetrics.notification.client.AccountServiceClient;
 import com.piggymetrics.notification.domain.NotificationType;
 import com.piggymetrics.notification.domain.Recipient;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -29,7 +29,7 @@ public class NotificationServiceImplTest {
 	@Mock
 	private EmailService emailService;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}

--- a/notification-service/src/test/java/com/piggymetrics/notification/service/RecipientServiceImplTest.java
+++ b/notification-service/src/test/java/com/piggymetrics/notification/service/RecipientServiceImplTest.java
@@ -7,16 +7,17 @@ import com.piggymetrics.notification.domain.NotificationSettings;
 import com.piggymetrics.notification.domain.NotificationType;
 import com.piggymetrics.notification.domain.Recipient;
 import com.piggymetrics.notification.repository.RecipientRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -29,7 +30,7 @@ public class RecipientServiceImplTest {
 	@Mock
 	private RecipientRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -45,9 +46,11 @@ public class RecipientServiceImplTest {
 		assertEquals(recipient, found);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailToFindRecipientWhenAccountNameIsEmpty() {
-		recipientService.findByAccountName("");
+		assertThrows(IllegalArgumentException.class, () -> {
+			recipientService.findByAccountName("");
+		});
 	}
 
 	@Test

--- a/pom.xml
+++ b/pom.xml
@@ -11,14 +11,14 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.0.3.RELEASE</version>
+		<version>2.2.13.RELEASE</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-		<spring-cloud.version>Finchley.RELEASE</spring-cloud.version>
-		<java.version>1.8</java.version>
+		<spring-cloud.version>Hoxton.RELEASE</spring-cloud.version>
+		<java.version>13</java.version>
 	</properties>
 
 	<dependencyManagement>

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -97,7 +97,7 @@
 			<plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
-				<version>0.7.6.201602180812</version>
+				<version>0.8.4</version>
 				<executions>
 					<execution>
 						<goals>

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/client/ExchangeRatesClientTest.java
@@ -2,18 +2,18 @@ package com.piggymetrics.statistics.client;
 
 import com.piggymetrics.statistics.domain.Currency;
 import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.time.LocalDate;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class ExchangeRatesClientTest {
 

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/controller/StatisticsControllerTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/controller/StatisticsControllerTest.java
@@ -11,14 +11,14 @@ import com.piggymetrics.statistics.domain.timeseries.DataPoint;
 import com.piggymetrics.statistics.domain.timeseries.DataPointId;
 import com.piggymetrics.statistics.service.StatisticsService;
 import com.sun.security.auth.UserPrincipal;
-import org.junit.Before;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
@@ -36,7 +36,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @SpringBootTest
 public class StatisticsControllerTest {
 
@@ -50,7 +50,7 @@ public class StatisticsControllerTest {
 
 	private MockMvc mockMvc;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 		this.mockMvc = MockMvcBuilders.standaloneSetup(statisticsController).build();

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/repository/DataPointRepositoryTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/repository/DataPointRepositoryTest.java
@@ -6,19 +6,19 @@ import com.piggymetrics.statistics.domain.timeseries.DataPoint;
 import com.piggymetrics.statistics.domain.timeseries.DataPointId;
 import com.piggymetrics.statistics.domain.timeseries.ItemMetric;
 import com.piggymetrics.statistics.domain.timeseries.StatisticMetric;
-import org.junit.Test;
-import org.junit.runner.RunWith;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.data.mongo.DataMongoTest;
-import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
 
 import java.math.BigDecimal;
 import java.util.Date;
 import java.util.List;
 
-import static org.junit.Assert.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
-@RunWith(SpringRunner.class)
+@ExtendWith(SpringExtension.class)
 @DataMongoTest
 public class DataPointRepositoryTest {
 

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/service/ExchangeRatesServiceImplTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/service/ExchangeRatesServiceImplTest.java
@@ -4,16 +4,17 @@ import com.google.common.collect.ImmutableMap;
 import com.piggymetrics.statistics.client.ExchangeRatesClient;
 import com.piggymetrics.statistics.domain.Currency;
 import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
 import java.math.BigDecimal;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.initMocks;
 
@@ -25,7 +26,7 @@ public class ExchangeRatesServiceImplTest {
 	@Mock
 	private ExchangeRatesClient client;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -88,8 +89,10 @@ public class ExchangeRatesServiceImplTest {
 		assertTrue(expectedConvertionResult.compareTo(result) == 0);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailToConvertWhenAmountIsNull() {
-		ratesService.convert(Currency.EUR, Currency.RUB, null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			ratesService.convert(Currency.EUR, Currency.RUB, null);
+		});
 	}
 }

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/service/StatisticsServiceImplTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/service/StatisticsServiceImplTest.java
@@ -11,8 +11,8 @@ import com.piggymetrics.statistics.domain.timeseries.DataPoint;
 import com.piggymetrics.statistics.domain.timeseries.ItemMetric;
 import com.piggymetrics.statistics.domain.timeseries.StatisticMetric;
 import com.piggymetrics.statistics.repository.DataPointRepository;
-import org.junit.Before;
-import org.junit.Test;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 
@@ -24,8 +24,9 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.mockito.AdditionalAnswers.returnsFirstArg;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
@@ -44,7 +45,7 @@ public class StatisticsServiceImplTest {
 	@Mock
 	private DataPointRepository repository;
 
-	@Before
+	@BeforeEach
 	public void setup() {
 		initMocks(this);
 	}
@@ -58,14 +59,18 @@ public class StatisticsServiceImplTest {
 		assertEquals(list, result);
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailToFindDataPointWhenAccountNameIsNull() {
-		statisticsService.findByAccountName(null);
+		assertThrows(IllegalArgumentException.class, () -> {
+			statisticsService.findByAccountName(null);
+		});
 	}
 
-	@Test(expected = IllegalArgumentException.class)
+	@Test
 	public void shouldFailToFindDataPointWhenAccountNameIsEmpty() {
-		statisticsService.findByAccountName("");
+		assertThrows(IllegalArgumentException.class, () -> {
+			statisticsService.findByAccountName("");
+		});
 	}
 
 	@Test


### PR DESCRIPTION
In order to modernise piggymetrics it would be nice to upgrade to Junit 5.

Spring Boot started to support Junit 5 in Spring Boot 2.2, so it makes sense to also:

- upgrade Spring Boot to 2.2.0.RELEASE, 
- upgrade Spring Cloud to Hoxton.RELEASE,
- update Java version to 13
- update JaCoCo maven plugin from 0.7.6 to 0.8.4 across all services
