### PR TITLE
Integrate and Configure Ehcache with Spring Cache Abstraction

### DIFF
--- a/.ee-bench/codegen/metadata.json
+++ b/.ee-bench/codegen/metadata.json
@@ -5,7 +5,9 @@
   "jvm_version": "17",
   "build_system": "maven",
   "expected": {
-    "fail_to_pass": [],
+    "fail_to_pass": [
+      "statistics-service:com.piggymetrics.statistics.service.CacheIntegrationTest"
+    ],
     "pass_to_pass": []
   },
   "environment": {

--- a/statistics-service/pom.xml
+++ b/statistics-service/pom.xml
@@ -53,6 +53,18 @@
 			<artifactId>spring-boot-starter-actuator</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-cache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>org.ehcache</groupId>
+			<artifactId>ehcache</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>javax.cache</groupId>
+			<artifactId>cache-api</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.springframework.cloud</groupId>
 			<artifactId>spring-cloud-starter-bus-amqp</artifactId>
 		</dependency>

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/StatisticsApplication.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/StatisticsApplication.java
@@ -2,11 +2,9 @@ package com.piggymetrics.statistics;
 
 import com.piggymetrics.statistics.repository.converter.DataPointIdReaderConverter;
 import com.piggymetrics.statistics.repository.converter.DataPointIdWriterConverter;
-import com.piggymetrics.statistics.service.security.CustomUserInfoTokenServices;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.autoconfigure.security.oauth2.resource.ResourceServerProperties;
+import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.context.annotation.Bean;
@@ -14,11 +12,11 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.mongodb.core.convert.CustomConversions;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableOAuth2Client;
-import org.springframework.security.oauth2.provider.token.ResourceServerTokenServices;
 
 import java.util.Arrays;
 
 @SpringBootApplication
+@EnableCaching
 @EnableDiscoveryClient
 @EnableOAuth2Client
 @EnableFeignClients

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/config/CacheConfig.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/config/CacheConfig.java
@@ -1,0 +1,120 @@
+package com.piggymetrics.statistics.config;
+
+import com.piggymetrics.statistics.domain.timeseries.DataPoint;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.ehcache.expiry.Duration;
+import org.ehcache.expiry.Expirations;
+import org.ehcache.jsr107.Eh107Configuration;
+import org.ehcache.jsr107.EhcacheCachingProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.CachingConfigurerSupport;
+import org.springframework.cache.interceptor.CacheErrorHandler;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.cache.jcache.JCacheCacheManager;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import javax.cache.Caching;
+import java.util.List;
+
+@Configuration
+public class CacheConfig extends CachingConfigurerSupport {
+
+    private static final Logger logger = LoggerFactory.getLogger(CacheConfig.class);
+
+    @Bean
+    @Override
+    public CacheManager cacheManager() {
+        try {
+            EhcacheCachingProvider provider = (EhcacheCachingProvider) Caching.getCachingProvider();
+            javax.cache.CacheManager jsr107CacheManager = provider.getCacheManager();
+            
+            // Create cache configuration for statisticsData
+            @SuppressWarnings("unchecked")
+            Class<List<DataPoint>> listClass = (Class<List<DataPoint>>) (Class<?>) List.class;
+            CacheConfigurationBuilder<String, List<DataPoint>> statisticsDataConfig = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(
+                    String.class, listClass,
+                    ResourcePoolsBuilder.heap(150))
+                .withExpiry(Expirations.timeToLiveExpiration(Duration.of(20, java.util.concurrent.TimeUnit.MINUTES)));
+            
+            // Create cache configuration for exchangeRates  
+            CacheConfigurationBuilder<String, Object> exchangeRatesConfig = CacheConfigurationBuilder
+                .newCacheConfigurationBuilder(
+                    String.class, Object.class,
+                    ResourcePoolsBuilder.heap(10))
+                .withExpiry(Expirations.timeToLiveExpiration(Duration.of(30, java.util.concurrent.TimeUnit.MINUTES)));
+            
+            // Create JSR-107 configurations with statistics enabled
+            javax.cache.configuration.Configuration<String, List<DataPoint>> statisticsJsr107Config = 
+                Eh107Configuration.fromEhcacheCacheConfiguration(statisticsDataConfig);
+            javax.cache.configuration.Configuration<String, Object> exchangeRatesJsr107Config = 
+                Eh107Configuration.fromEhcacheCacheConfiguration(exchangeRatesConfig);
+            
+            // Create the caches if they don't already exist
+            if (jsr107CacheManager.getCache("statisticsData") == null) {
+                jsr107CacheManager.createCache("statisticsData", statisticsJsr107Config);
+            }
+            if (jsr107CacheManager.getCache("exchangeRates") == null) {
+                jsr107CacheManager.createCache("exchangeRates", exchangeRatesJsr107Config);
+            }
+
+            jsr107CacheManager.enableStatistics("statisticsData", true);
+            jsr107CacheManager.enableStatistics("exchangeRates", true);
+
+            logger.info("Ehcache initialized with programmatic configuration");
+            logger.info("Available cache names: {}", jsr107CacheManager.getCacheNames());
+            return new JCacheCacheManager(jsr107CacheManager);
+            
+        } catch (Exception e) {
+            logger.error("Error initializing Ehcache", e);
+            throw new RuntimeException("Failed to initialize cache", e);
+        }
+    }
+
+    @Override
+    public CacheErrorHandler errorHandler() {
+        return new CacheErrorHandler() {
+            @Override
+            public void handleCacheGetError(RuntimeException exception, org.springframework.cache.Cache cache, Object key) {
+                logger.error("Cache get error for cache '{}' and key '{}': {}", cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCachePutError(RuntimeException exception, org.springframework.cache.Cache cache, Object key, Object value) {
+                logger.error("Cache put error for cache '{}' and key '{}': {}", cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheEvictError(RuntimeException exception, org.springframework.cache.Cache cache, Object key) {
+                logger.error("Cache evict error for cache '{}' and key '{}': {}", cache.getName(), key, exception.getMessage());
+            }
+
+            @Override
+            public void handleCacheClearError(RuntimeException exception, org.springframework.cache.Cache cache) {
+                logger.error("Cache clear error for cache '{}': {}", cache.getName(), exception.getMessage());
+            }
+        };
+    }
+
+    @Override
+    public KeyGenerator keyGenerator() {
+        return (target, method, params) -> {
+            StringBuilder key = new StringBuilder();
+            key.append(target.getClass().getSimpleName()).append(".");
+            key.append(method.getName()).append(":");
+            for (Object param : params) {
+                if (param != null) {
+                    key.append(param.toString()).append(",");
+                }
+            }
+            if (key.charAt(key.length() - 1) == ',') {
+                key.deleteCharAt(key.length() - 1);
+            }
+            return key.toString();
+        };
+    }
+}

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/service/ExchangeRatesServiceImpl.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/service/ExchangeRatesServiceImpl.java
@@ -7,20 +7,18 @@ import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
-import java.time.LocalDate;
 import java.util.Map;
 
 @Service
 public class ExchangeRatesServiceImpl implements ExchangeRatesService {
 
 	private static final Logger log = LoggerFactory.getLogger(ExchangeRatesServiceImpl.class);
-
-	private ExchangeRatesContainer container;
 
 	@Autowired
 	private ExchangeRatesClient client;
@@ -29,12 +27,12 @@ public class ExchangeRatesServiceImpl implements ExchangeRatesService {
 	 * {@inheritDoc}
 	 */
 	@Override
+	@Cacheable(value = "exchangeRates", key = "#root.methodName")
 	public Map<Currency, BigDecimal> getCurrentRates() {
+		log.debug("getCurrentRates called - fetching from external service");
 
-		if (container == null || !container.getDate().equals(LocalDate.now())) {
-			container = client.getRates(Currency.getBase());
-			log.info("exchange rates has been updated: {}", container);
-		}
+		ExchangeRatesContainer container = client.getRates(Currency.getBase());
+		log.info("exchange rates has been updated: {}", container);
 
 		return ImmutableMap.of(
 				Currency.EUR, container.getRates().get(Currency.EUR.name()),

--- a/statistics-service/src/main/java/com/piggymetrics/statistics/service/StatisticsServiceImpl.java
+++ b/statistics-service/src/main/java/com/piggymetrics/statistics/service/StatisticsServiceImpl.java
@@ -10,6 +10,8 @@ import com.piggymetrics.statistics.repository.DataPointRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
 import org.springframework.stereotype.Service;
 import org.springframework.util.Assert;
 
@@ -39,8 +41,10 @@ public class StatisticsServiceImpl implements StatisticsService {
 	 * {@inheritDoc}
 	 */
 	@Override
+	@Cacheable(value = "statisticsData", key = "#accountName")
 	public List<DataPoint> findByAccountName(String accountName) {
 		Assert.hasLength(accountName);
+		log.debug("findByAccountName called for account: {} - fetching from database", accountName);
 		return repository.findByIdAccount(accountName);
 	}
 
@@ -48,6 +52,7 @@ public class StatisticsServiceImpl implements StatisticsService {
 	 * {@inheritDoc}
 	 */
 	@Override
+	@CacheEvict(value = "statisticsData", key = "#accountName")
 	public DataPoint save(String accountName, Account account) {
 
 		Instant instant = LocalDate.now().atStartOfDay()

--- a/statistics-service/src/test/java/com/piggymetrics/statistics/service/CacheIntegrationTest.java
+++ b/statistics-service/src/test/java/com/piggymetrics/statistics/service/CacheIntegrationTest.java
@@ -1,0 +1,300 @@
+package com.piggymetrics.statistics.service;
+
+import com.piggymetrics.statistics.client.ExchangeRatesClient;
+import com.piggymetrics.statistics.domain.Account;
+import com.piggymetrics.statistics.domain.Currency;
+import com.piggymetrics.statistics.domain.ExchangeRatesContainer;
+import com.piggymetrics.statistics.domain.Saving;
+import com.piggymetrics.statistics.domain.timeseries.DataPoint;
+import com.piggymetrics.statistics.domain.timeseries.DataPointId;
+import com.piggymetrics.statistics.repository.DataPointRepository;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.junit.Rule;
+import org.springframework.boot.test.system.OutputCaptureRule;
+import org.springframework.cache.CacheManager;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.math.BigDecimal;
+import java.util.*;
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+@RunWith(SpringRunner.class)
+@SpringBootTest(
+        properties = {
+                "spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration",
+                "logging.level.org.springframework.cache.interceptor=TRACE"
+        }
+)
+public class CacheIntegrationTest {
+
+    @Autowired
+    private StatisticsService statisticsService;
+
+    @Autowired
+    private ExchangeRatesService exchangeRatesService;
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @MockBean
+    private DataPointRepository repository;
+
+    @MockBean
+    private ExchangeRatesClient exchangeRatesClient;
+    
+    @Rule
+    public OutputCaptureRule output = new OutputCaptureRule();
+
+    private List<DataPoint> testDataPoints;
+    private Account testAccount;
+
+    @Before
+    public void setUp() {
+        // Clear all caches before each test
+        cacheManager.getCacheNames().forEach(cacheName ->
+                cacheManager.getCache(cacheName).clear());
+
+        // Setup test data
+        testDataPoints = new ArrayList<>();
+        DataPoint dataPoint = new DataPoint();
+        dataPoint.setId(new DataPointId("testuser", new Date()));
+        testDataPoints.add(dataPoint);
+
+        // Setup test account
+        testAccount = new Account();
+        testAccount.setIncomes(new ArrayList<>());
+        testAccount.setExpenses(new ArrayList<>());
+
+        Saving saving = new Saving();
+        saving.setAmount(new BigDecimal(1000));
+        saving.setCurrency(Currency.USD);
+        testAccount.setSaving(saving);
+
+        // Mock exchange rates client
+        ExchangeRatesContainer mockContainer = new ExchangeRatesContainer();
+        mockContainer.setBase(Currency.USD);
+        mockContainer.setDate(java.time.LocalDate.now());
+        Map<String, BigDecimal> rates = new HashMap<>();
+        rates.put("EUR", new BigDecimal("0.85"));
+        rates.put("RUB", new BigDecimal("75.0"));
+        mockContainer.setRates(rates);
+        when(exchangeRatesClient.getRates(Currency.USD)).thenReturn(mockContainer);
+    }
+
+    @Test
+    public void testStatisticsCacheHitOnSecondCall() {
+        String accountName = "testuser";
+        when(repository.findByIdAccount(accountName)).thenReturn(testDataPoints);
+
+        List<DataPoint> result1 = statisticsService.findByAccountName(accountName);
+
+        List<DataPoint> result2 = statisticsService.findByAccountName(accountName);
+
+        assertNotNull("First result should not be null", result1);
+        assertNotNull("Second result should not be null", result2);
+        assertEquals("Both results should have same size", result1.size(), result2.size());
+
+        verify(repository, times(1)).findByIdAccount(accountName);
+    }
+
+    @Test
+    public void testCacheEvictionOnSave() {
+        String accountName = "testuser";
+        when(repository.findByIdAccount(accountName)).thenReturn(testDataPoints);
+        when(repository.save(any(DataPoint.class))).thenReturn(new DataPoint());
+
+        List<DataPoint> result1 = statisticsService.findByAccountName(accountName);
+        assertNotNull("Initial result should not be null", result1);
+
+        verify(repository, times(1)).findByIdAccount(accountName);
+
+        statisticsService.save(accountName, testAccount);
+
+        List<DataPoint> result2 = statisticsService.findByAccountName(accountName);
+
+        assertNotNull("Result after cache eviction should not be null", result2);
+
+        verify(repository, times(2)).findByIdAccount(accountName);
+        verify(repository, times(1)).save(any(DataPoint.class));
+    }
+
+    @Test
+    public void testCacheManagerIsConfigured() {
+        assertNotNull("CacheManager should be configured", cacheManager);
+        assertTrue("StatisticsData cache should be available",
+                cacheManager.getCacheNames().contains("statisticsData"));
+        assertTrue("ExchangeRates cache should be available",
+                cacheManager.getCacheNames().contains("exchangeRates"));
+    }
+
+    @Test
+    public void testCacheWithEmptyResult() {
+        String accountName = "emptyaccount";
+        when(repository.findByIdAccount(accountName)).thenReturn(Collections.emptyList());
+
+        List<DataPoint> result1 = statisticsService.findByAccountName(accountName);
+        List<DataPoint> result2 = statisticsService.findByAccountName(accountName);
+
+        assertNotNull("Result should not be null", result1);
+        assertTrue("Result should be empty", result1.isEmpty());
+        assertTrue("Cached result should be empty", result2.isEmpty());
+
+        verify(repository, times(1)).findByIdAccount(accountName);
+    }
+
+    @Test
+    public void testMultipleAccountStatisticsCached() {
+        String accountName1 = "testuser1";
+        String accountName2 = "testuser2";
+
+        List<DataPoint> dataPoints1 = List.of(new DataPoint());
+        List<DataPoint> dataPoints2 = Arrays.asList(new DataPoint(), new DataPoint());
+
+        when(repository.findByIdAccount(accountName1)).thenReturn(dataPoints1);
+        when(repository.findByIdAccount(accountName2)).thenReturn(dataPoints2);
+
+        List<DataPoint> result1a = statisticsService.findByAccountName(accountName1);
+        List<DataPoint> result2a = statisticsService.findByAccountName(accountName2);
+        List<DataPoint> result1b = statisticsService.findByAccountName(accountName1);
+        List<DataPoint> result2b = statisticsService.findByAccountName(accountName2);
+
+        assertNotNull("Account1 first call result should not be null", result1a);
+        assertNotNull("Account2 first call result should not be null", result2a);
+        assertNotNull("Account1 second call result should not be null", result1b);
+        assertNotNull("Account2 second call result should not be null", result2b);
+
+        assertEquals("Account1 results should match size", result1a.size(), result1b.size());
+        assertEquals("Account2 results should match size", result2a.size(), result2b.size());
+
+        verify(repository, times(1)).findByIdAccount(accountName1);
+        verify(repository, times(1)).findByIdAccount(accountName2);
+    }
+
+    @Test
+    public void testExchangeRatesCacheHitOnSecondCall() {
+        Map<Currency, BigDecimal> result1 = exchangeRatesService.getCurrentRates();
+
+        Map<Currency, BigDecimal> result2 = exchangeRatesService.getCurrentRates();
+
+        assertNotNull("First result should not be null", result1);
+        assertNotNull("Second result should not be null", result2);
+        assertEquals("Both results should be equal", result1, result2);
+
+        verify(exchangeRatesClient, times(1)).getRates(Currency.USD);
+    }
+
+    @Test
+    public void testExchangeRatesCacheReturnsCorrectValues() {
+        Map<Currency, BigDecimal> rates = exchangeRatesService.getCurrentRates();
+
+        assertNotNull("Exchange rates should not be null", rates);
+        assertTrue("Should contain EUR rate", rates.containsKey(Currency.EUR));
+        assertTrue("Should contain RUB rate", rates.containsKey(Currency.RUB));
+        assertTrue("Should contain USD rate", rates.containsKey(Currency.USD));
+        assertEquals("USD rate should be 1.0", BigDecimal.ONE, rates.get(Currency.USD));
+        assertEquals("EUR rate should match mock", new BigDecimal("0.85"), rates.get(Currency.EUR));
+        assertEquals("RUB rate should match mock", new BigDecimal("75.0"), rates.get(Currency.RUB));
+    }
+
+    @Test
+    public void testCacheHitMissStatistics() {
+        String accountName = "stats-test-user";
+        when(repository.findByIdAccount(accountName)).thenReturn(testDataPoints);
+
+        cacheManager.getCache("statisticsData").clear();
+        
+        List<DataPoint> result1 = statisticsService.findByAccountName(accountName);
+        assertNotNull("First result should not be null", result1);
+        
+        List<DataPoint> result2 = statisticsService.findByAccountName(accountName);
+        assertNotNull("Second result should not be null", result2);
+        
+        verify(repository, times(1)).findByIdAccount(accountName);
+        
+        assertEquals("Both results should have same content", result1.size(), result2.size());
+        
+        org.springframework.cache.Cache cache = cacheManager.getCache("statisticsData");
+        assertNotNull("Cache should exist", cache);
+        
+        org.springframework.cache.Cache.ValueWrapper cachedValue = cache.get(accountName);
+        assertNotNull("Value should be cached", cachedValue);
+        
+        System.out.println("Cache hit/miss test completed - verified through repository call count");
+    }
+
+    @Test
+    public void testCacheEvictionStatistics() {
+        String accountName = "eviction-test-user";
+        when(repository.findByIdAccount(accountName)).thenReturn(testDataPoints);
+        when(repository.save(any(DataPoint.class))).thenReturn(new DataPoint());
+
+        cacheManager.getCache("statisticsData").clear();
+        
+        statisticsService.findByAccountName(accountName);
+        
+        org.springframework.cache.Cache cache = cacheManager.getCache("statisticsData");
+        org.springframework.cache.Cache.ValueWrapper cachedValueBefore = cache.get(accountName);
+        assertNotNull("Value should be cached before eviction", cachedValueBefore);
+        
+        statisticsService.save(accountName, testAccount);
+        
+        org.springframework.cache.Cache.ValueWrapper cachedValueAfter = cache.get(accountName);
+        assertNull("Value should be evicted from cache", cachedValueAfter);
+        
+        System.out.println("Cache eviction test completed - verified cache value was removed");
+    }
+
+    @Test
+    public void testExchangeRatesCacheStatistics() {
+        cacheManager.getCache("exchangeRates").clear();
+        
+        Map<Currency, BigDecimal> rates1 = exchangeRatesService.getCurrentRates();  // Cache miss
+        Map<Currency, BigDecimal> rates2 = exchangeRatesService.getCurrentRates();  // Cache hit
+        Map<Currency, BigDecimal> rates3 = exchangeRatesService.getCurrentRates();  // Cache hit
+        
+        assertNotNull("First call should return rates", rates1);
+        assertNotNull("Second call should return rates", rates2);
+        assertNotNull("Third call should return rates", rates3);
+        
+        verify(exchangeRatesClient, times(1)).getRates(Currency.USD);
+        
+        org.springframework.cache.Cache cache = cacheManager.getCache("exchangeRates");
+        org.springframework.cache.Cache.ValueWrapper cachedValue = cache.get("getCurrentRates");
+        assertNotNull("Exchange rates should be cached", cachedValue);
+        
+        System.out.println("Exchange rates cache test completed - verified through client call count");
+    }
+
+    @Test
+    public void logsHitAndMiss() {
+        String accountName = "A";
+
+        // Ensure clean cache to force a miss on first call
+        Objects.requireNonNull(cacheManager.getCache("statisticsData")).clear();
+
+        // Mock repository to return some data for the account
+        when(repository.findByIdAccount(accountName)).thenReturn(Arrays.asList(new DataPoint()));
+
+        // First call should be a cache MISS, second a HIT
+        statisticsService.findByAccountName(accountName); // MISS
+        statisticsService.findByAccountName(accountName); // HIT
+
+        String logs = output.toString();
+
+        assertTrue("Expected cache miss to be logged",
+                logs.contains("No cache entry for key 'A' in cache(s) [statisticsData]"));
+        assertTrue("Expected cache hit to be logged",
+                logs.contains("Cache entry for key 'A' found in cache 'statisticsData'"));
+
+        // Confirm cache actually hit by repository being called only once
+        verify(repository, times(1)).findByIdAccount(accountName);
+    }
+}


### PR DESCRIPTION
Task Description:
Integrate Ehcache as the primary cache provider within statistics service, leveraging Spring's Cache abstraction. Configure Ehcache using either XML or Java-based configuration, and ensure that the application recognizes it as the main CacheManager. Annotate key service methods in StatisticsService with @Cacheable to cache frequently requested data, thereby reducing response times and backend load. ExchangeRatesService caching field should be substituted with @Cacheable annotation on the method. Proper configuration and management should enable efficient cache usage, observability, and easy maintenance.

Acceptance Criteria:

- Ehcache is integrated as the CacheManager and configured correctly in the application.
- ExchangeRatesService and StatisticsService implementation methods are annotated with @Cacheable and successfully caches results.
- Cache hits and misses are correctly logged or observable through management tools.
- Tests confirm that cached data is returned on repeated calls with identical parameters and that new data is fetched on cache misses.
- Configuration and code changes follow project conventions and all tests in statistics service pass.
- Documentation explains cache configuration and usage within the project.
